### PR TITLE
Implement hill climbing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "bitstring",
         "Bitstrings",
         "miette",
-        "recombinator"
+        "recombinator",
+        "thiserror"
     ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,11 @@ dependencies = [
  "ec-core",
  "ec-linear",
  "flume",
+ "itertools 0.14.0",
  "miette",
  "rand 0.9.0",
  "rayon",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -189,7 +191,7 @@ source = "registry+https://github.com/UMM-CSci-4553-S25/registry.git"
 checksum = "767cfb7cf1887768f0082e82c058b3182b3105ec09e31ba3cfc743c7a77ebc09"
 dependencies = [
  "ec_macros",
- "itertools",
+ "itertools 0.13.0",
  "macro_railroad_annotation",
  "miette",
  "num-traits",
@@ -197,7 +199,7 @@ dependencies = [
  "rand 0.9.0",
  "rayon",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -211,7 +213,7 @@ dependencies = [
  "num-traits",
  "rand 0.9.0",
  "static_assertions",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -334,6 +336,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,7 +453,7 @@ dependencies = [
  "supports-unicode",
  "terminal_size",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-width",
 ]
 
@@ -775,7 +786,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -783,6 +803,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ bon = { version = "3.3.2", features = ["implied-bounds"] }
 ec-core = { version = "0.1.0-course.3", registry = "ec-course" }
 ec-linear = { version = "0.1.0-course.3", registry = "ec-course" }
 flume = "0.11.1"
+itertools = "0.14.0"
 miette = { version = "7.4.0", features = ["fancy"] }
 rand = "0.9.0"
 rayon = "1.10.0"
+thiserror = "2.0.11"

--- a/examples/count_ones_hill_climber/main.rs
+++ b/examples/count_ones_hill_climber/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), HillClimberError<GenomeSizeConversionError>> {
         .mutator(WithOneOverLength)
         .scorer(scorer)
         .inspector(|solution_chunk| update_best(&mut best, solution_chunk))
-        .parallel_search(false)
+        // .parallel_search(false)
         .build();
 
     hill_climber.search()?;

--- a/examples/count_ones_hill_climber/main.rs
+++ b/examples/count_ones_hill_climber/main.rs
@@ -1,0 +1,47 @@
+use course_helpers::{
+    hill_climber::{HillClimber, HillClimberError},
+    inspector::update_best,
+};
+use ec_core::{
+    distributions::collection::ConvertToCollectionGenerator,
+    individual::scorer::FnScorer,
+    test_results::{Score, TestResults},
+};
+use ec_linear::{
+    genome::bitstring::Bitstring,
+    mutator::with_one_over_length::{GenomeSizeConversionError, WithOneOverLength},
+};
+use rand::distr::StandardUniform;
+
+#[must_use]
+pub fn count_ones(bits: &[bool]) -> TestResults<Score<u64>> {
+    bits.iter().copied().map(u64::from).collect()
+}
+
+fn main() -> Result<(), HillClimberError<GenomeSizeConversionError>> {
+    let num_to_create = 1_000_000;
+
+    let num_bits = 32;
+
+    let scorer = FnScorer(|bitstring: &Bitstring| count_ones(&bitstring.bits));
+
+    // Create a `Distribution` that generates `Bitstring`s when sampled
+    let genome_maker = StandardUniform.into_collection_generator(num_bits);
+
+    let mut best = None;
+
+    let mut hill_climber = HillClimber::builder()
+        .num_to_search(num_to_create)
+        .num_children_per_step(10)
+        .always_replace(true)
+        .genome_maker(genome_maker)
+        .mutator(WithOneOverLength)
+        .scorer(scorer)
+        .inspector(|solution_chunk| update_best(&mut best, solution_chunk))
+        .parallel_search(false)
+        .build();
+
+    hill_climber.search()?;
+
+    Ok(())
+}

--- a/examples/count_ones_hill_climber/main.rs
+++ b/examples/count_ones_hill_climber/main.rs
@@ -38,7 +38,6 @@ fn main() -> Result<(), HillClimberError<GenomeSizeConversionError>> {
         .mutator(WithOneOverLength)
         .scorer(scorer)
         .inspector(|solution_chunk| update_best(&mut best, solution_chunk))
-        // .parallel_search(false)
         .build();
 
     hill_climber.search()?;

--- a/examples/count_ones_random_search/main.rs
+++ b/examples/count_ones_random_search/main.rs
@@ -1,7 +1,4 @@
-use course_helpers::{
-    inspector::update_best,
-    random_search::{RandomSearch, RandomSearchError},
-};
+use course_helpers::{inspector::update_best, random_search::RandomSearch};
 use ec_core::{
     distributions::collection::ConvertToCollectionGenerator,
     individual::scorer::FnScorer,
@@ -15,7 +12,7 @@ pub fn count_ones(bits: &[bool]) -> TestResults<Score<u64>> {
     bits.iter().copied().map(u64::from).collect()
 }
 
-fn main() -> Result<(), RandomSearchError> {
+fn main() {
     let num_to_create = 1_000_000;
 
     let num_bits = 32;
@@ -37,7 +34,5 @@ fn main() -> Result<(), RandomSearchError> {
         .parallel_search(true)
         .build();
 
-    random_search.search()?;
-
-    Ok(())
+    random_search.search();
 }

--- a/examples/integer_hill_climber/main.rs
+++ b/examples/integer_hill_climber/main.rs
@@ -1,0 +1,49 @@
+use rand::distr::{uniform, Distribution, StandardUniform, Uniform};
+use std::convert::Infallible;
+
+use course_helpers::{hill_climber::HillClimber, inspector::update_best};
+use ec_core::{individual::scorer::FnScorer, operator::mutator::Mutator, test_results::Error};
+
+struct IntegerMutator {
+    distribution: Uniform<i32>,
+}
+
+impl IntegerMutator {
+    pub fn new(max_step: i32) -> Result<Self, uniform::Error> {
+        let distribution = Uniform::new(-max_step, max_step)?;
+        Ok(Self { distribution })
+    }
+}
+
+impl Mutator<i32> for IntegerMutator {
+    type Error = Infallible;
+
+    fn mutate<R: rand::Rng + ?Sized>(&self, genome: i32, rng: &mut R) -> Result<i32, Self::Error> {
+        Ok(genome.saturating_add(self.distribution.sample(rng)))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let num_to_create = 1_000_000;
+    let target: i32 = 589;
+    let scorer = FnScorer(|value: &i32| Error(value.abs_diff(target)));
+
+    // Create a `Distribution` that generates `i64`s when sampled
+    let genome_maker = StandardUniform;
+
+    let mut best = None;
+
+    let mut hill_climber = HillClimber::builder()
+        .num_to_search(num_to_create)
+        .num_children_per_step(10)
+        .always_replace(false)
+        .genome_maker(genome_maker)
+        .mutator(IntegerMutator::new(100_000)?)
+        .scorer(scorer)
+        .inspector(|solution_chunk| update_best(&mut best, solution_chunk))
+        .build();
+
+    hill_climber.search()?;
+
+    Ok(())
+}

--- a/examples/integer_random_search/main.rs
+++ b/examples/integer_random_search/main.rs
@@ -1,16 +1,14 @@
-use course_helpers::{
-    inspector::update_best,
-    random_search::{RandomSearch, RandomSearchError},
-};
+use course_helpers::{inspector::update_best, random_search::RandomSearch};
 use ec_core::{individual::scorer::FnScorer, test_results::Error};
+use rand::distr::StandardUniform;
 
-fn main() -> Result<(), RandomSearchError> {
+fn main() {
     let num_to_create = 1_000_000;
     let target = 589;
-    let scorer = FnScorer(|value: &i64| Error(value.abs_diff(target)));
+    let scorer = FnScorer(|value: &i32| Error(value.abs_diff(target)));
 
     // Create a `Distribution` that generates `i64`s when sampled
-    let genome_maker = rand::distr::StandardUniform;
+    let genome_maker = StandardUniform;
 
     let mut best = None;
 
@@ -25,13 +23,11 @@ fn main() -> Result<(), RandomSearchError> {
         .parallel_search(true)
         .build();
 
-    random_search.search()?;
+    random_search.search();
 
     let (best_sample_number, best_genome, best_score) = best.unwrap();
     println!(
         "Best solution found: sample_number: {}, genome: {:?}, score: {}",
         best_sample_number, best_genome, best_score
     );
-
-    Ok(())
 }

--- a/src/hill_climber.rs
+++ b/src/hill_climber.rs
@@ -46,8 +46,6 @@ where
     #[builder(default = false)]
     always_replace: bool,
 
-    // #[builder(default = true)]
-    // parallel_search: bool,
     genome_maker: GM,
     mutator: Mut,
     scorer: Scr,
@@ -67,59 +65,7 @@ where
     pub fn search(&mut self) -> Result<(), HillClimberError<Mut::Error>> {
         let initial_candidate = self.genome_maker.sample(&mut rng());
         self.search_sequential(initial_candidate)
-        // if self.parallel_search {
-        //     self.search_parallel(initial_candidate)
-        // } else {
-        //     self.search_sequential(initial_candidate)
-        // }
     }
-
-    // /// Search the given number of samples in parallel.
-    // ///
-    // /// This function uses Rayon to parallelize the search. Because the `inspector`
-    // /// may contain data that must be mutated by each thread in the parallel search
-    // /// (e.g., a "best so far" field), the `inspector` is wrapped in a `Mutex` to
-    // /// ensure that only one thread can access it at a time. That creates a potential
-    // /// bottleneck, but it's a simple way to ensure that the `inspector` is thread-safe.
-    // /// We break the search into chunks of 1,000 samples to reduce the number of times
-    // /// the `Mutex` is locked and unlocked, reducing the contention.
-    // fn search_parallel(
-    //     &mut self,
-    //     initial_candidate: Ge,
-    // ) -> Result<(), HillClimberError<Mut::Error>> {
-    //     let mut rng = rand::rng();
-
-    //     let initial_score = self.scorer.score(&initial_candidate);
-    //     let mut current_scored_best = (0, initial_candidate, initial_score);
-
-    //     (self.inspector)(slice::from_ref(&current_scored_best));
-
-    //     for indices in &(1..self.num_to_search).chunks(self.num_children_per_step) {
-    //         let best_in_chunk = (&indices)
-    //             .into_iter()
-    //             .par_bridge()
-    //             .map(|sample_number| -> Result<_, HillClimberError<Mut::Error>> {
-    //                 let child = self
-    //                     .mutator
-    //                     .mutate(current_scored_best.1.clone(), &mut rng)?;
-    //                 let score = self.scorer.score(&child);
-    //                 Ok((sample_number, child, score))
-    //             })
-    //             .process_results(|iter| {
-    //                 iter.max_by(|(_, _, first_score), (_, _, second_score)| {
-    //                     first_score.cmp(second_score)
-    //                 })
-    //             })?
-    //             .ok_or(HillClimberError::ZeroSizedChunk)?;
-
-    //         if self.always_replace || best_in_chunk.2 > current_scored_best.2 {
-    //             current_scored_best = best_in_chunk;
-    //             (self.inspector)(slice::from_ref(&current_scored_best));
-    //         }
-    //     }
-
-    //     Ok(())
-    // }
 
     fn search_sequential(
         &mut self,

--- a/src/hill_climber.rs
+++ b/src/hill_climber.rs
@@ -1,0 +1,152 @@
+use std::{marker::PhantomData, sync::Mutex};
+
+use bon::Builder;
+use ec_core::{
+    individual::scorer::Scorer,
+    operator::{mutator::Mutator, selector::best},
+};
+use itertools::Itertools;
+use rand::{prelude::Distribution, rng};
+use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
+
+#[derive(Debug, thiserror::Error)]
+pub enum HillClimberError<MutationError> {
+    Mutation(#[from] MutationError),
+}
+
+#[derive(Debug, Builder)]
+pub struct HillClimber<Ge, GM, Mut, Sc, Scr, Ins>
+// You typically wouldn't put all these constraints on the struct itself, instead
+// you'd put them on the `impl` block for the struct. But I'm doing it here to
+// make the constraints more visible and (hopefully) make some of the error
+// messages more helpful for people new to Rust.
+where
+    Ge: Clone + std::fmt::Debug + Sync + Send,
+    GM: Distribution<Ge> + Sync + Send,
+    Mut: Mutator<Ge> + Sync + Send,
+    Sc: Ord + PartialOrd + std::fmt::Debug + Sync + Send,
+    Scr: Scorer<Ge, Score = Sc> + Sync + Send,
+    // The number of this particular genome, the genome, and its score.
+    Ins: FnMut(&[&(usize, Ge, Sc)]) + Sync + Send,
+{
+    // We need `PhantomData` because `RandomSearch` depends on the type `Ge` but doesn't
+    // actually contain an instance of it. This is a way to tell Rust that `Ge`
+    // is a type that we care about, but we don't actually have an instance of.
+    // The `builder(field)` attribute tells the `Builder` derive macro that this
+    // is a field that is _not_ specified in the build process.
+    #[builder(field)]
+    _p: PhantomData<Ge>,
+
+    #[builder(default = 1_000)]
+    num_to_search: usize,
+
+    #[builder(default = 1)]
+    num_children_per_step: usize,
+
+    /// Do we _always_ replace the current solution with the best of the "child"
+    /// solutions, even if they aren't better than the current solution?
+    #[builder(default = false)]
+    always_replace: bool,
+
+    #[builder(default = true)]
+    parallel_search: bool,
+
+    genome_maker: GM,
+    mutator: Mut,
+    scorer: Scr,
+    inspector: Ins,
+}
+
+impl<Ge, GM, Mut, Sc, Scr, Ins> HillClimber<Ge, GM, Mut, Sc, Scr, Ins>
+where
+    Ge: Clone + std::fmt::Debug + Sync + Send,
+    GM: Distribution<Ge> + Sync + Send,
+    Mut: Mutator<Ge> + Sync + Send,
+    Sc: Ord + PartialOrd + std::fmt::Debug + Sync + Send,
+    Scr: Scorer<Ge, Score = Sc> + Sync + Send,
+    // The number of this particular genome, the genome, and its score.
+    Ins: FnMut(&[&(usize, Ge, Sc)]) + Sync + Send,
+{
+    pub fn search(&mut self) -> Result<(), HillClimberError<Mut::Error>> {
+        let initial_candidate = self.genome_maker.sample(&mut rng());
+        if self.parallel_search {
+            self.search_parallel(initial_candidate)
+        } else {
+            self.search_sequential(initial_candidate)
+        }
+    }
+
+    /// Search the given number of samples in parallel.
+    ///
+    /// This function uses Rayon to parallelize the search. Because the `inspector`
+    /// may contain data that must be mutated by each thread in the parallel search
+    /// (e.g., a "best so far" field), the `inspector` is wrapped in a `Mutex` to
+    /// ensure that only one thread can access it at a time. That creates a potential
+    /// bottleneck, but it's a simple way to ensure that the `inspector` is thread-safe.
+    /// We break the search into chunks of 1,000 samples to reduce the number of times
+    /// the `Mutex` is locked and unlocked, reducing the contention.
+    fn search_parallel(
+        &mut self,
+        initial_candidate: Ge,
+    ) -> Result<(), HillClimberError<Mut::Error>> {
+        // // A *little* searching on a simple problem suggests that something like
+        // // 1,000 samples per chunk is a good balance between the overhead of locking
+        // // and the benefit of parallelism. This is a good starting point, but you
+        // // may want to experiment with different chunk sizes.
+        // const CHUNK_SIZE: usize = 1_000;
+        // let inspector = Mutex::new(&mut self.inspector);
+        // (0..self.num_to_search)
+        //     .into_par_iter()
+        //     .chunks(CHUNK_SIZE)
+        //     .for_each(|chunk| {
+        //         let solution_chunk = chunk
+        //             .into_iter()
+        //             .map(|sample_number| {
+        //                 // Generate a random genome as a "solution"
+        //                 let sample = self.genome_maker.sample(&mut rng());
+        //                 // Score the solution
+        //                 let score = self.scorer.score(&sample);
+        //                 (sample_number, sample, score)
+        //             })
+        //             .collect::<Vec<_>>();
+        //         (inspector.lock().unwrap())(&solution_chunk);
+        //     });
+
+        // Ok(())
+        todo!()
+    }
+
+    fn search_sequential(
+        &mut self,
+        current_candidate: Ge,
+    ) -> Result<(), HillClimberError<Mut::Error>> {
+        let mut rng = rand::rng();
+
+        let current_score = self.scorer.score(&current_candidate);
+        let mut current_scored_best = (0, current_candidate, current_score);
+
+        for indices in &(1..self.num_to_search).chunks(self.num_children_per_step) {
+            let mut best_scored_child = None;
+            for sample_number in indices {
+                let child = self
+                    .mutator
+                    .mutate(current_scored_best.1.clone(), &mut rng)?;
+                let score = self.scorer.score(&child);
+                match best_scored_child {
+                    None => best_scored_child = Some((sample_number, child, score)),
+                    Some((_, _, best_score)) if score > best_score => {
+                        best_scored_child = Some((sample_number, child, score))
+                    }
+                    _ => {}
+                }
+            }
+            let best_scored_child = best_scored_child.unwrap();
+            if self.always_replace || best_scored_child.2 > current_scored_best.2 {
+                current_scored_best = best_scored_child;
+                (self.inspector)(&[&current_scored_best]);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/hill_climber.rs
+++ b/src/hill_climber.rs
@@ -1,16 +1,10 @@
 use core::slice;
-use std::{cmp::Ordering, marker::PhantomData, sync::Mutex};
+use std::marker::PhantomData;
 
 use bon::Builder;
-use ec_core::{
-    individual::scorer::Scorer,
-    operator::{mutator::Mutator, selector::best},
-};
+use ec_core::{individual::scorer::Scorer, operator::mutator::Mutator};
 use itertools::Itertools;
 use rand::{prelude::Distribution, rng};
-use rayon::iter::{
-    IndexedParallelIterator, IntoParallelIterator, ParallelBridge, ParallelIterator,
-};
 
 #[derive(Debug, thiserror::Error)]
 pub enum HillClimberError<MutationError> {

--- a/src/hill_climber.rs
+++ b/src/hill_climber.rs
@@ -22,13 +22,13 @@ pub struct HillClimber<Ge, GM, Mut, Sc, Scr, Ins>
 // make the constraints more visible and (hopefully) make some of the error
 // messages more helpful for people new to Rust.
 where
-    Ge: Clone + std::fmt::Debug + Sync + Send,
-    GM: Distribution<Ge> + Sync + Send,
-    Mut: Mutator<Ge> + Sync + Send,
-    Sc: Ord + PartialOrd + std::fmt::Debug + Sync + Send,
-    Scr: Scorer<Ge, Score = Sc> + Sync + Send,
+    Ge: Clone,
+    GM: Distribution<Ge>,
+    Mut: Mutator<Ge>,
+    Sc: Ord + PartialOrd,
+    Scr: Scorer<Ge, Score = Sc>,
     // The number of this particular genome, the genome, and its score.
-    Ins: FnMut(&[(usize, Ge, Sc)]) + Sync + Send,
+    Ins: FnMut(&[(usize, Ge, Sc)]),
 {
     // We need `PhantomData` because `RandomSearch` depends on the type `Ge` but doesn't
     // actually contain an instance of it. This is a way to tell Rust that `Ge`
@@ -57,13 +57,13 @@ where
 
 impl<Ge, GM, Mut, Sc, Scr, Ins> HillClimber<Ge, GM, Mut, Sc, Scr, Ins>
 where
-    Ge: Clone + std::fmt::Debug + Sync + Send,
-    GM: Distribution<Ge> + Sync + Send,
-    Mut: Mutator<Ge> + Sync + Send,
-    Sc: Ord + PartialOrd + std::fmt::Debug + Sync + Send + Clone,
-    Scr: Scorer<Ge, Score = Sc> + Sync + Send,
+    Ge: Clone,
+    GM: Distribution<Ge>,
+    Mut: Mutator<Ge>,
+    Sc: Ord + PartialOrd + Clone,
+    Scr: Scorer<Ge, Score = Sc>,
     // The number of this particular genome, the genome, and its score.
-    Ins: FnMut(&[(usize, Ge, Sc)]) + Sync + Send,
+    Ins: FnMut(&[(usize, Ge, Sc)]),
 {
     pub fn search(&mut self) -> Result<(), HillClimberError<Mut::Error>> {
         let initial_candidate = self.genome_maker.sample(&mut rng());

--- a/src/hill_climber.rs
+++ b/src/hill_climber.rs
@@ -8,7 +8,10 @@ use rand::{prelude::Distribution, rng};
 
 #[derive(Debug, thiserror::Error)]
 pub enum HillClimberError<MutationError> {
+    #[error(transparent)]
     Mutation(#[from] MutationError),
+
+    #[error("Processed zero-sized chunk")]
     ZeroSizedChunk,
 }
 

--- a/src/inspector/best.rs
+++ b/src/inspector/best.rs
@@ -14,17 +14,17 @@ use std::fmt::Display;
 /// #
 /// let mut best = None;
 ///
-/// let first_chunk = [(0, "a", 5), (1, "b", 8), (2, "c", 9)];
+/// let first_chunk = [&(0, "a", 5), &(1, "b", 8), &(2, "c", 9)];
 /// update_best(&mut best, &first_chunk);
 /// assert_eq!(best, Some((2, "c", 9)));
 ///
-/// let second_chunk = [(3, "d", 2), (4, "e", 11), (5, "f", 4)];
+/// let second_chunk = [&(3, "d", 2), &(4, "e", 11), &(5, "f", 4)];
 /// update_best(&mut best, &second_chunk);
 /// assert_eq!(best, Some((4, "e", 11)));
 /// ```
 pub fn update_best<Genome, Score>(
     current_best: &mut Option<(usize, Genome, Score)>,
-    candidate_solutions: &[(usize, Genome, Score)],
+    candidate_solutions: &[&(usize, Genome, Score)],
 ) where
     Genome: Clone + Display,
     Score: Clone + Display + PartialOrd,
@@ -67,11 +67,11 @@ mod tests {
     fn update_best_test() {
         let mut best = None;
 
-        let first_chunk = [(0, "a", 5), (1, "b", 8), (2, "c", 9)];
+        let first_chunk = [&(0, "a", 5), &(1, "b", 8), &(2, "c", 9)];
         update_best(&mut best, &first_chunk);
         assert_eq!(best, Some((2, "c", 9)));
 
-        let second_chunk = [(3, "d", 2), (4, "e", 11), (5, "f", 4)];
+        let second_chunk = [&(3, "d", 2), &(4, "e", 11), &(5, "f", 4)];
         update_best(&mut best, &second_chunk);
         assert_eq!(best, Some((4, "e", 11)));
     }

--- a/src/inspector/best.rs
+++ b/src/inspector/best.rs
@@ -24,7 +24,7 @@ use std::fmt::Display;
 /// ```
 pub fn update_best<Genome, Score>(
     current_best: &mut Option<(usize, Genome, Score)>,
-    candidate_solutions: &[&(usize, Genome, Score)],
+    candidate_solutions: &[(usize, Genome, Score)],
 ) where
     Genome: Clone + Display,
     Score: Clone + Display + PartialOrd,

--- a/src/inspector/best.rs
+++ b/src/inspector/best.rs
@@ -14,11 +14,11 @@ use std::fmt::Display;
 /// #
 /// let mut best = None;
 ///
-/// let first_chunk = [&(0, "a", 5), &(1, "b", 8), &(2, "c", 9)];
+/// let first_chunk = [(0, "a", 5), (1, "b", 8), (2, "c", 9)];
 /// update_best(&mut best, &first_chunk);
 /// assert_eq!(best, Some((2, "c", 9)));
 ///
-/// let second_chunk = [&(3, "d", 2), &(4, "e", 11), &(5, "f", 4)];
+/// let second_chunk = [(3, "d", 2), (4, "e", 11), (5, "f", 4)];
 /// update_best(&mut best, &second_chunk);
 /// assert_eq!(best, Some((4, "e", 11)));
 /// ```
@@ -67,11 +67,11 @@ mod tests {
     fn update_best_test() {
         let mut best = None;
 
-        let first_chunk = [&(0, "a", 5), &(1, "b", 8), &(2, "c", 9)];
+        let first_chunk = [(0, "a", 5), (1, "b", 8), (2, "c", 9)];
         update_best(&mut best, &first_chunk);
         assert_eq!(best, Some((2, "c", 9)));
 
-        let second_chunk = [&(3, "d", 2), &(4, "e", 11), &(5, "f", 4)];
+        let second_chunk = [(3, "d", 2), (4, "e", 11), (5, "f", 4)];
         update_best(&mut best, &second_chunk);
         assert_eq!(best, Some((4, "e", 11)));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod ec_run;
+pub mod hill_climber;
 pub mod inspector;
 pub mod random_search;


### PR DESCRIPTION
This adds hill climbing, with examples.

There are several other minor refactorings and clean-ups along the way:
- We removed the return type from `RandomSearch` since it was just carrying an error, and upon examination it turned out that no error was ever generated.
- We added the `#[error(…)]` attribute to `HillClimberError` so it would implement `Display` and could be used with `anyhow`.

We decided not to implement parallelism here; see #3 for the related issue if you'd like to work on that later.